### PR TITLE
Nifty Cloud SDKのバージョンを1.7から1.11.beta7にアップデート

### DIFF
--- a/vagrant-niftycloud.gemspec
+++ b/vagrant-niftycloud.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "vagrant-nifycloud"
 
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec-core", "~> 2.12.2"
-  s.add_development_dependency "rspec-expectations", "~> 2.12.1"
-  s.add_development_dependency "rspec-mocks", "~> 2.12.1"
+  s.add_development_dependency "rspec-core", "3.7.0"
+  s.add_development_dependency "rspec-expectations", "3.7.0"
+  s.add_development_dependency "rspec-mocks", "3.7.0"
   s.add_dependency "nifty-cloud-sdk", "1.11.beta7"
 
   # The following block of code determines the files that should be included

--- a/vagrant-niftycloud.gemspec
+++ b/vagrant-niftycloud.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-core", "~> 2.12.2"
   s.add_development_dependency "rspec-expectations", "~> 2.12.1"
   s.add_development_dependency "rspec-mocks", "~> 2.12.1"
-  s.add_dependency "nifty-cloud-sdk", ">= 1.7"
+  s.add_dependency "nifty-cloud-sdk", "1.11.beta7"
 
   # The following block of code determines the files that should be included
   # in the gem. It does this by reading all the files in the directory where


### PR DESCRIPTION
* #8 に関連して、e-mediumなどe-*タイプやmedium24などのサーバに対応するため、Nifty Cloud SDKのバージョンをアップデート
* rspec-*についてもビルドが通らないため最新のバージョンにアップデート
